### PR TITLE
fixed heatmap losing events of module it is decorating

### DIFF
--- a/module.js
+++ b/module.js
@@ -43,7 +43,10 @@ M.block_heatmap = {
                     info += '&nbsp;<span class="block_heatmap_users block_heatmap_icon_' + weight + '"">';
                     info += this.config[i].distinctusers;
                     info += '</span></div>';
-                    module.innerHTML = module.innerHTML + info;
+                    let wrapper = document.createElement('div');
+                    wrapper.innerHTML = info;
+                    let infodiv = wrapper.firstChild;
+                    module.appendChild(infodiv);
                 }
             }
         }


### PR DESCRIPTION
Heatmap decorates course modules with innerHTML.
Since it reconstitutes the element, it breaks the functionality of any elements in the module description that have events attached (except those attached inline).
Fixed by using DOM commands to attach the heatmap to the module.